### PR TITLE
Fix capitalize css

### DIFF
--- a/ukf/static/css/default.css
+++ b/ukf/static/css/default.css
@@ -146,7 +146,7 @@
 /* -- Sidebar -- */
 .sidebar li {
     list-style: none;
-    text-transform: capitalize;
+    /* text-transform: capitalize; */
     letter-spacing: 0.04em;
     font-weight: 500;
     font-size: 13px;

--- a/ukf/static/css/style.css
+++ b/ukf/static/css/style.css
@@ -297,7 +297,7 @@ iframe {
 .menu > li > a {
     padding: 25px 35px;
     font-size: 13px;
-    text-transform: capitalize;
+    /* text-transform: capitalize; */
     font-weight:400;
     display: inline-block;
     color: #fff;
@@ -416,7 +416,7 @@ iframe {
     font-size:14px;
     color:inherit;
     padding:0 0 6px;
-    text-transform:capitalize;
+    /* text-transform:capitalize; */
     letter-spacing: 1px;
     font-weight:600;
 }


### PR DESCRIPTION
Removing text-tranfsform:capitalize; from menu items so 'eCloud' doesn't become 'ECloud'.